### PR TITLE
Force rrdtool exec in "C" locale, as expected by Number

### DIFF
--- a/lib/proc.js
+++ b/lib/proc.js
@@ -7,7 +7,7 @@ function exec (args, cb) {
 
   var stdout = [];
   var stderr = [];
-  var p = child_process.spawn('rrdtool', args);
+  var p = child_process.spawn('rrdtool', args, { env: {LANG: 'C'} });
 
   p.stdout.on('data', function (chunk) {
     stdout.push(chunk);


### PR DESCRIPTION
rrdtool renders numbers according to LANG env var. 
If default LANG env is, for example,  «fr_FR.UTF8», decimal separator will be comma instead of dot and leads in a parsing failure when submitting it to Number(c) line 116
Maybe related with #1 ?